### PR TITLE
Apply plugin via plugins block instead of using buildscript

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -1,26 +1,9 @@
 import com.example.MyPluginExtension
 
-buildscript {
-    repositories {
-        mavenLocal()
-    }
-    dependencies {
-        classpath("com.example:my-plugin:1.0.0")
-    }
-}
-
 plugins {
     kotlin("jvm")
     id("application")
-}
-
-// because my-plugin is published to mavenLocal
-// we must apply my-plugin here instead of plugins block
-apply(plugin = "my-plugin")
-
-repositories {
-    mavenCentral()
-    mavenLocal()
+    id("com.example.my-plugin")
 }
 
 configure<MyPluginExtension> {

--- a/demo/settings.gradle.kts
+++ b/demo/settings.gradle.kts
@@ -1,14 +1,17 @@
 pluginManagement {
     repositories {
         mavenCentral()
+        mavenLocal()
     }
     plugins {
         kotlin("jvm") version "1.9.0" apply false
+        id("com.example.my-plugin") version "1.0.0" apply false
     }
 }
 
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 gradlePlugin {
     plugins {
         create("myPlugin") {
-            id = "my-plugin"
+            id = "com.example.my-plugin"
             implementationClass = "com.example.MyPlugin"
         }
     }
@@ -26,8 +26,8 @@ publishing {
     publications {
         register("mavenJava", MavenPublication::class) {
             from(components["kotlin"])
-            groupId = "com.example"
-            artifactId = "my-plugin"
+            groupId = "com.example.my-plugin"
+            artifactId = "com.example.my-plugin.gradle.plugin"
             version = "1.0.0"
         }
     }

--- a/gradle-plugin/src/main/kotlin/com/example/MyPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/example/MyPlugin.kt
@@ -53,7 +53,7 @@ class MyPlugin : KotlinCompilerPluginSupportPlugin {
 
     override fun getPluginArtifact(): SubpluginArtifact {
         return SubpluginArtifact(
-            groupId = "com.example",
+            groupId = "com.example.my-plugin",
             artifactId = "kotlin-plugin",
             version = "1.0.0",
         )

--- a/kotlin-plugin/build.gradle.kts
+++ b/kotlin-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ publishing {
     publications {
         register("mavenJava", MavenPublication::class) {
             from(components["kotlin"])
-            groupId = "com.example"
+            groupId = "com.example.my-plugin"
             artifactId = "kotlin-plugin"
             version = "1.0.0"
         }


### PR DESCRIPTION
Applying plugin via `buildscript` is a obsolete way.
So, I reconfigured publication settings for `gradle-plugin` correctly, and now it works same as other normal gradle plugins!

> before
```kotlin
buildscript {
    repositories {
        mavenLocal()
    }
    dependencies {
        classpath("com.example:my-plugin:1.0.0")
    }
}

...

// because my-plugin is published to mavenLocal
// we must apply my-plugin here instead of plugins block
apply(plugin = "my-plugin")

repositories {
    mavenCentral()
    mavenLocal()
}
```

> after
```kotlin
plugins {
    id("com.example.my-plugin")
}
```